### PR TITLE
linux-yocto-artik: Use new artik-next branch

### DIFF
--- a/recipes-kernel/linux/linux-yocto-artik.bb
+++ b/recipes-kernel/linux/linux-yocto-artik.bb
@@ -2,9 +2,9 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 LINUX_VERSION = "3.10.9"
 
-SRC_URI = "git://git@bitbucket.org/rulemotion/linux-artik.git;protocol=ssh;branch=artik"
+SRC_URI = "git://git@bitbucket.org/rulemotion/linux-artik.git;protocol=ssh;branch=artik-next"
 
-SRCREV = "630456f987daef7e342917e91730e777a8032809"
+SRCREV = "4097fccd4576dd96c8cc40bb50458596e0cc58ee"
 
 inherit kernel
 require recipes-kernel/linux/linux-yocto.inc


### PR DESCRIPTION
This branch contains a new code drop from Samsung with changes
for MIPI screen support mainly.

Signed-off-by: Florin Sarbu <florin@resin.io>