### PR TITLE
linux-yocto-artik.bb: Fix asix.ko autoload

### DIFF
--- a/recipes-kernel/linux/files/fix_autoload_asix_module.patch
+++ b/recipes-kernel/linux/files/fix_autoload_asix_module.patch
@@ -1,0 +1,57 @@
+For spi devices in OF the modalias exposed to userspace is
+spi:<node type>, for the Asix AX88796C driver this is spi:ax88796c
+
+# cat /sys/devices/13920000.spi/spi_master/spi0/spi0.0/modalias
+spi:ax88796c
+
+
+On the other hand, the asix module does not use the same alias:
+
+# modinfo asix | grep alias
+alias:          of:N*T*Casix,ax88796c*
+
+
+This happens because the SPI subsystem hardcodes spi:<spi->modalias>, as seen in
+drivers/spi/spi.c:
+
+static int spi_uevent(struct device *dev, struct kobj_uevent_env *env)
+{
+	const struct spi_device><------>*spi = to_spi_device(dev);
+
+	add_uevent_var(env, "MODALIAS=%s%s", SPI_MODULE_PREFIX, spi->modalias);
+	return 0;
+}
+
+Thus we define the spi id table, add ax88796c to it and have the alias as reported by
+the spi driver added so that userspace can correctly autoload the module for the device.
+
+
+Upstream-Status: Pending
+
+Signed-off-by: Florin Sarbu <florin@resin.io>
+
+Index: kernel-source/drivers/net/ethernet/asix/ax88796c_main.c
+===================================================================
+--- kernel-source.orig/drivers/net/ethernet/asix/ax88796c_main.c
++++ kernel-source/drivers/net/ethernet/asix/ax88796c_main.c
+@@ -1571,6 +1571,12 @@ static const struct of_device_id ax88796
+ MODULE_DEVICE_TABLE(of, ax88796c_dt_ids);
+ #endif
+ 
++static const struct spi_device_id asix_id[] = {
++	{ "ax88796c", 0 },
++	{ }
++};
++MODULE_DEVICE_TABLE(spi, asix_id);
++
+ static struct spi_driver ax88796c_spi_driver = {
+ 	.driver = {
+ 		.name = DRV_NAME,
+@@ -1583,6 +1589,7 @@ static struct spi_driver ax88796c_spi_dr
+ 	.remove = ax88796c_remove,
+ 	.suspend = ax88796c_suspend,
+ 	.resume = ax88796c_resume,
++	.id_table=asix_id,
+ };
+ 
+ /* ----------------------------------------------------------------------------

--- a/recipes-kernel/linux/linux-yocto-artik.bb
+++ b/recipes-kernel/linux/linux-yocto-artik.bb
@@ -5,6 +5,7 @@ LINUX_VERSION = "3.10.9"
 SRC_URI = " \
     git://github.com/SamsungARTIK/linux-artik.git;protocol=https;branch=artik-exynos/v3.10.x \
     file://0001-Btrfs-fix-not-being-able-to-find-skinny-extents-duri.patch \
+    file://fix_autoload_asix_module.patch \
     "
 
 SRCREV = "84a5d7636d3bdb0eb0c2385d973b9471d3681917"


### PR DESCRIPTION
With latest kernel update, CONFIG_SPI_AX88796C has been set as a
module and asix.ko does not autoload resulting in no eth interface.

For spi devices in OF the modalias exposed to userspace is
spi:<node type>, for the Asix AX88796C driver this is spi:ax88796c

$ cat /sys/devices/13920000.spi/spi_master/spi0/spi0.0/modalias
spi:ax88796c

On the other hand, the asix module does not use the same alias:

$ modinfo asix | grep alias
alias:          of:N*T*Casix,ax88796c*

This happens because the SPI subsystem hardcodes spi:<spi->modalias>, as seen in
drivers/spi/spi.c:

static int spi_uevent(struct device *dev, struct kobj_uevent_env *env)
{
        const struct spi_device><------>*spi = to_spi_device(dev);

        add_uevent_var(env, "MODALIAS=%s%s", SPI_MODULE_PREFIX, spi->modalias);
        return 0;
}

Thus we define the spi id table, add ax88796c to it and have the alias as reported by
the spi driver added so that userspace can correctly autoload the module for the device.

Signed-off-by: Florin Sarbu <florin@resin.io>