### PR TITLE
linux-yocto-artik.bb: Use correct KCONFIG_MODE="--alldefconfig"

### DIFF
--- a/recipes-kernel/linux/linux-yocto-artik.bb
+++ b/recipes-kernel/linux/linux-yocto-artik.bb
@@ -17,11 +17,6 @@ PV = "${LINUX_VERSION}+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 
-# for artik 5 and artik 10 we build the kernel in the source tree
-B = "${S}"
-
-do_configure_prepend() {
-    rm ${B}/.config
-}
+KCONFIG_MODE="--alldefconfig"
 
 COMPATIBLE_MACHINE = "(artik5|artik10)"


### PR DESCRIPTION
The Samsung artik5 and artik10 use a partial defconfig for their kernels.
Thus, we need to use Yocto's KCONFIG_MODE="--alldefconfig" mechanism in this case.

More details here:
https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta-skeleton/recipes-kernel/linux/linux-yocto-custom.bb

By using this, we also can skip the in-tree build of the kernel.

Signed-off-by: Florin Sarbu <florin@resin.io>