### PR TITLE
bcm4354-bt.bb: Add systemd service to unblock bluetooth (for the master branch)

### DIFF
--- a/recipes-bsp/bcm4354-bluetooth/bcm4354-bt.bb
+++ b/recipes-bsp/bcm4354-bluetooth/bcm4354-bt.bb
@@ -12,12 +12,16 @@ SRC_URI = " \
     file://brcm_patchram_plus \
     file://fwdown.sh \
     file://hciconf.sh \
+    file://rfkill-unblock.service \
     "
 S = "${WORKDIR}"
 
 inherit systemd
 
-SYSTEMD_SERVICE_${PN} = "brcm-bt-firmware.service"
+SYSTEMD_SERVICE_${PN} = " \
+    brcm-bt-firmware.service \
+    rfkill-unblock.service \
+    "
 
 RDEPENDS_${PN} = " \
     bluez5 \
@@ -32,13 +36,13 @@ do_install() {
 
         if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
             install -d ${D}${systemd_unitdir}/system
-            install -c -m 0644 ${WORKDIR}/brcm-bt-firmware.service ${D}${systemd_unitdir}/system
+            install -c -m 0644 ${WORKDIR}/brcm-bt-firmware.service ${WORKDIR}/rfkill-unblock.service ${D}${systemd_unitdir}/system
             sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
                 -e 's,@BASE_SBINDIR@,${base_sbindir},g' \
                 -e 's,@SBINDIR@,${sbindir},g' \
                 -e 's,@BINDIR@,${bindir},g' \
                 -e 's,@SYS_CONFDIR@,${sysconfdir},g' \
-                ${D}${systemd_unitdir}/system/brcm-bt-firmware.service
+                ${D}${systemd_unitdir}/system/brcm-bt-firmware.service ${D}${systemd_unitdir}/system/rfkill-unblock.service
         fi
 }
 

--- a/recipes-bsp/bcm4354-bluetooth/bcm4354-bt.bb
+++ b/recipes-bsp/bcm4354-bluetooth/bcm4354-bt.bb
@@ -28,22 +28,30 @@ RDEPENDS_${PN} = " \
     "
 
 do_install() {
-        install -d  ${D}/etc/bluetooth/
-        install -m 0755 ${WORKDIR}/BCM4354_003.001.012.0353.0745_Samsung_Artik_ORC.hcd ${WORKDIR}/brcm_patchram_plus ${WORKDIR}/fwdown.sh ${WORKDIR}/hciconf.sh ${D}/etc/bluetooth/
+    install -d  ${D}/etc/bluetooth/
+    install -m 0755 ${WORKDIR}/BCM4354_003.001.012.0353.0745_Samsung_Artik_ORC.hcd \
+                    ${WORKDIR}/brcm_patchram_plus \
+                    ${WORKDIR}/fwdown.sh \
+                    ${WORKDIR}/hciconf.sh \
+                    ${D}/etc/bluetooth/
 
-        install -d ${D}/etc/udev/rules.d/
-        install -m 0755 ${WORKDIR}/10-local.rules ${D}/etc/udev/rules.d/
+    install -d ${D}/etc/udev/rules.d/
+    install -m 0755 ${WORKDIR}/10-local.rules ${D}/etc/udev/rules.d/
 
-        if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
-            install -d ${D}${systemd_unitdir}/system
-            install -c -m 0644 ${WORKDIR}/brcm-bt-firmware.service ${WORKDIR}/rfkill-unblock.service ${D}${systemd_unitdir}/system
-            sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
-                -e 's,@BASE_SBINDIR@,${base_sbindir},g' \
-                -e 's,@SBINDIR@,${sbindir},g' \
-                -e 's,@BINDIR@,${bindir},g' \
-                -e 's,@SYS_CONFDIR@,${sysconfdir},g' \
-                ${D}${systemd_unitdir}/system/brcm-bt-firmware.service ${D}${systemd_unitdir}/system/rfkill-unblock.service
-        fi
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${WORKDIR}/brcm-bt-firmware.service \
+                           ${WORKDIR}/rfkill-unblock.service \
+                           ${D}${systemd_unitdir}/system
+
+        sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+            -e 's,@BASE_SBINDIR@,${base_sbindir},g' \
+            -e 's,@SBINDIR@,${sbindir},g' \
+            -e 's,@BINDIR@,${bindir},g' \
+            -e 's,@SYS_CONFDIR@,${sysconfdir},g' \
+            ${D}${systemd_unitdir}/system/brcm-bt-firmware.service \
+            ${D}${systemd_unitdir}/system/rfkill-unblock.service
+    fi
 }
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/bcm4354-bluetooth/files/brcm-bt-firmware.service
+++ b/recipes-bsp/bcm4354-bluetooth/files/brcm-bt-firmware.service
@@ -5,7 +5,7 @@ Before=bluetooth.target
 [Service]
 Type=forking
 ExecStart=/etc/bluetooth/fwdown.sh
-PIDFILE=/run/brcm_patchram_plus.pid
+PIDFile=/run/brcm_patchram_plus.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/recipes-bsp/bcm4354-bluetooth/files/rfkill-unblock.service
+++ b/recipes-bsp/bcm4354-bluetooth/files/rfkill-unblock.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=RFKill-Unblock All Devices
+After=systemd-rfkill@.service
+Before=bluetooth.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/rfkill unblock all
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
We need to unblock the bluetooth soft rfkill switch for bluetooth to work.
This service unblocks all devices in fact and that should not have a negative
impact as we do not want anything blocked by default.

Signed-off-by: Florin Sarbu <florin@resin.io>