### PR TITLE
artik-sdimg.bbclass: Update deprecated variable

### DIFF
--- a/classes/artik-sdimg.bbclass
+++ b/classes/artik-sdimg.bbclass
@@ -41,13 +41,13 @@ IMAGE_ROOTFS_ALIGNMENT = "4096"
 SDIMG_ROOTFS_TYPE ?= "ext4"
 SDIMG_ROOTFS = "${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.${SDIMG_ROOTFS_TYPE}"
 
-IMAGE_DEPENDS_artik-sdimg = " \
-			parted-native \
-			mtools-native \
-			dosfstools-native \
-			e2fsprogs-native \
-			virtual/kernel \
-			u-boot \
+do_image_artik_sdimg[depends] = " \
+			parted-native:do_populate_sysroot \
+			mtools-native:do_populate_sysroot \
+			dosfstools-native:do_populate_sysroot \
+			e2fsprogs-native:do_populate_sysroot \
+			virtual/kernel:do_deploy \
+			u-boot:do_deploy \
 			"
 # Exynos Boot magic
 BL1_SYMLINK ?= "bl1.bin"


### PR DESCRIPTION
On current master pokey this error was reported:

  ERROR: .../images/...-image.bb: Deprecated variable(s) found:\
  "IMAGE_DEPENDS_artik-sdimg". \
  Use do_image_<type>[depends] += "<recipe>:<task>" instead

Bug: https://github.com/resin-os/meta-artik/issues/27
Change-Id: Ic324dce667408de1b5d7268d48879ed53af749df
Origin: http://github.com/TizenTeam/meta-artik
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>