### PR TITLE
secure-boot-artik533s: Add depend on boot-firmware-artik53x (on master)

### DIFF
--- a/recipes-bsp/secure-boot/secure-boot-artik533s.bb
+++ b/recipes-bsp/secure-boot/secure-boot-artik533s.bb
@@ -15,6 +15,8 @@ inherit deploy
 
 S = "${WORKDIR}"
 
+DEPENDS += "boot-firmware-artik53x"
+
 do_patch[noexec] = "1"
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
@@ -25,7 +27,7 @@ do_deploy () {
     install -m 755  ${WORKDIR}/secureos.img ${DEPLOYDIR}
 
     # gen_nexell_image_mon
-    ${WORKDIR}/artik533s_codesigner -sign ${DEPLOYDIR}/bl_mon.img
+    ${WORKDIR}/artik533s_codesigner -sign ${DEPLOY_DIR_IMAGE}/bl_mon.img
 
     # gen_nexell_image_secure
     ${WORKDIR}/artik533s_codesigner -sign ${DEPLOYDIR}/secureos.img


### PR DESCRIPTION
We need bl_mon.img deployed in order to sign it (bl_mon.img is provided by boot-firmware-artik53x)

Also use the correct image deploy directory when referencing bl_mon.img

Signed-off-by: Florin Sarbu <florin@resin.io>