### PR TITLE
Fix bluetooth (on pyro branch)

### DIFF
--- a/recipes-bsp/sd8x-rfkill/files/mrvl.conf
+++ b/recipes-bsp/sd8x-rfkill/files/mrvl.conf
@@ -1,0 +1,5 @@
+mlan
+sd8xxx
+bluetooth
+bt8xxx
+sd8x_rfkill

--- a/recipes-bsp/sd8x-rfkill/sd8x-rfkill.bb
+++ b/recipes-bsp/sd8x-rfkill/sd8x-rfkill.bb
@@ -3,7 +3,10 @@ SECTION = "connectivity"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
-SRC_URI = "file://bt-wifi-on.service"
+SRC_URI = " \
+    file://bt-wifi-on.service \
+    file://mrvl.conf \
+"
 S = "${WORKDIR}"
 
 inherit systemd
@@ -12,6 +15,9 @@ SYSTEMD_SERVICE_${PN} = "bt-wifi-on.service"
 
 do_install() {
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${sysconfdir}/modules-load.d
+        install -m 0644 ${WORKDIR}/mrvl.conf ${D}${sysconfdir}/modules-load.d
+
         install -d ${D}${systemd_unitdir}/system
         install -c -m 0644 ${WORKDIR}/bt-wifi-on.service \
                            ${D}${systemd_unitdir}/system


### PR DESCRIPTION
for fixing bluetooth on artik530 and artik533s

The WiFi/BT kernel modules need to be loaded in a specific order. Otherwise
bluetooth won't work and the following can be seen in dmesg:

[    7.695000] sd8x-rfkill sd8x-rfkill: bt-wlan-1p8-gpio undefined
[    9.645000] BT: Loading driver
[    9.755000] BT Request firmware: mrvl/sdsd8977_combo_v2.bin
[   11.085000] BT: FW download over, size 554160 bytes
[   12.785000] BT FW is active(17)
[   17.795000] BT: module_cfg_cmd(0xf1): timeout sendcmdflag=1
[   17.800000] BT init command failed!
[   17.800000] BT: sbi_register_conf_dpc failed. Terminating download
[   17.800000] BT Firmware Init Failed
[   17.805000] BT: Delete
[   17.810000] sdio_bt: probe of mmc1:0001:2 failed with error -1
[   17.810000] BT: Driver loaded successfully

Signed-off-by: Florin Sarbu <florin@resin.io>