### PR TITLE
linux-yocto-artik53x.bb: Compile device tree overlays (on pyro)

### DIFF
--- a/recipes-kernel/linux/linux-yocto-artik53x.bb
+++ b/recipes-kernel/linux/linux-yocto-artik53x.bb
@@ -10,7 +10,6 @@ SRCREV_artik530 = "release/A530s-OS-18.05.00"
 SRC_URI_artik533s = "git://github.com/SamsungARTIK/linux-artik.git;protocol=https;branch=A533s-OS-18.05.00"
 SRCREV_artik533s = "release/A533s-OS-18.05.00"
 
-inherit kernel
 require recipes-kernel/linux/linux-yocto.inc
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
@@ -20,3 +19,20 @@ S = "${WORKDIR}/git"
 KCONFIG_MODE="--alldefconfig"
 
 COMPATIBLE_MACHINE = "(artik530|artik533s)"
+
+# compile the device tree overlays
+do_compile_append() {
+    oe_runmake dtbs CC="${KERNEL_CC} " LD="${KERNEL_LD}" ${KERNEL_EXTRA_ARGS}
+}
+
+do_install_append() {
+    mkdir -p ${D}/boot/overlays
+    install -m 0644 ${B}/arch/arm/boot/dts/overlays/*.dtbo ${D}/boot/overlays
+}
+
+FILES_kernel-devicetree_append = " /${KERNEL_IMAGEDEST}/overlays/*"
+
+do_deploy_append() {
+    install -d ${DEPLOYDIR}/overlays/
+    cp ${D}/boot/overlays/* ${DEPLOYDIR}/overlays
+}


### PR DESCRIPTION
The Samsung kernel for artik530 and artik533s has additional overlays
which we compile now and add them to the kernel-devicetree package.

Signed-off-by: Florin Sarbu <florin@resin.io>